### PR TITLE
add style-elements compatible Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# HTML 5 Drag and Drop API
+# HTML 5 Drag and Drop API for Style Elements
 This library handles dragging and dropping using the API
 from the HTML 5 recommendation at
 https://www.w3.org/TR/html/editing.html#drag-and-drop.
 
 It provides attributes and a model/update to handle
 dragging and dropping between your elements.
+
+This is a straight port of https://github.com/norpan/elm-html5-drag-drop to
+support the [Style Elements](http://package.elm-lang.org/packages/mdgriffith/style-elements/latest)
 
 ## Usage
 ```elm
@@ -35,10 +38,8 @@ update msg model =
 
 view =
    ...
-   div (... ++ Html5.DragDrop.draggable DragDropMsg dragId) [...]
+   el (... ++ Html5.DragDrop.draggableElement DragDropMsg dragId) (...)
    ...
-   div (... ++ Html5.DragDrop.droppable DragDropMsg dropId) [...]
+   row (... ++ Html5.DragDrop.droppableElement DragDropMsg dropId) [...]
 ```
 
-## Example
-https://ellie-app.com/rP5HtD5Mvya1/0

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.1.0",
-  "summary": "This library handles dragging and dropping using the HTML5 API",
-  "repository": "https://github.com/norpan/elm-html5-drag-drop.git",
+  "version": "1.0.0",
+  "summary": "This library handles dragging and dropping of style elements using the HTML5 API",
+  "repository": "https://github.com/tilmans/elm-style-elements-drag-drop.git",
   "license": "BSD3",
   "source-directories": ["src"],
   "exposed-modules": ["Html5.DragDrop"],

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,17 +1,14 @@
 {
-    "version": "1.1.0",
-    "summary": "This library handles dragging and dropping using the HTML5 API",
-    "repository": "https://github.com/norpan/elm-html5-drag-drop.git",
-    "license": "BSD3",
-    "source-directories": [
-        "src"
-    ],
-    "exposed-modules": [
-        "Html5.DragDrop"
-    ],
-    "dependencies": {
-        "elm-lang/core": "5.1.1 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0"
-    },
-    "elm-version": "0.18.0 <= v < 0.19.0"
+  "version": "1.1.0",
+  "summary": "This library handles dragging and dropping using the HTML5 API",
+  "repository": "https://github.com/norpan/elm-html5-drag-drop.git",
+  "license": "BSD3",
+  "source-directories": ["src"],
+  "exposed-modules": ["Html5.DragDrop"],
+  "dependencies": {
+    "elm-lang/core": "5.1.1 <= v < 6.0.0",
+    "elm-lang/html": "2.0.0 <= v < 3.0.0",
+    "norpan/elm-html5-drag-drop": "1.1.0 <= v < 2.0.0"
+  },
+  "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
I wanted to use the library for style-elements which does not expose Html.Attribute. I've added two new versions of the draggable and droppable which can be used for style-elements.

Not sure you want to pull in the extra dependency though. If you prefer I can also publish a forked package.