### PR TITLE
Expose Model and Msg type constructors

### DIFF
--- a/src/Html5/DragDrop.elm
+++ b/src/Html5/DragDrop.elm
@@ -1,5 +1,5 @@
 module Html5.DragDrop exposing
-    ( Model, init, Msg, Position, update, updateSticky
+    ( Model(..), init, Msg(..), Position, update, updateSticky
     , draggable, droppable
     , getDragId, getDropId, getDroppablePosition
     , getDragstartEvent


### PR DESCRIPTION
I ran into issues when trying to display UI elements only when the user is in the middle of a drag operation. 

Then only solution I found was monkey-patching the Module so that it exposes Model and Msg.
This will provide a much greater degree of flexibility.
Looking forward to your feedback.

How I used the model:
```elm

    -- resolve the component from the target dict
    maybeResolved = case globalModel.dragDrop of
      Dragging draggable -> List.Extra.getAt (getId draggable) globalModel.uiLib
      DraggedOver draggable _ _ -> List.Extra.getAt (getId draggable) globalModel.uiLib
      _ -> Nothing
```