### PR TITLE
Expose Msg(..) so it can be used with Svg

### DIFF
--- a/src/Html5/DragDrop.elm
+++ b/src/Html5/DragDrop.elm
@@ -1,5 +1,5 @@
 module Html5.DragDrop exposing
-    ( Model, init, Msg, Position, update, updateSticky
+    ( Model, init, Msg(..), Position, update, updateSticky
     , draggable, droppable
     , getDragId, getDropId, getDroppablePosition
     , getDragstartEvent


### PR DESCRIPTION
For a project I am trying to write a version of `draggable` and `droppable` for `Svg` and for Elm-UI. Unfortunately `Msg` is opaque which is a good thing normally but it makes it hard to write a View in other View libraries.

This PR exposes `Msg(..)` so I can reimplement those functions.